### PR TITLE
Remove extra wildcard in core-dev.install file

### DIFF
--- a/ubuntu/debian/libgz-transport-core-dev.install
+++ b/ubuntu/debian/libgz-transport-core-dev.install
@@ -5,7 +5,6 @@ usr/include/*/transport[0-9][0-9]/*/transport/detail/*.hh
 usr/lib/*/lib*-transport[0-9][0-9].so
 usr/lib/*/pkgconfig/*-transport[0-9][0-9].pc
 usr/lib/*/cmake/*-transport[0-9][0-9]/*-transport*
-usr/lib/*/*/transport[0-9][0-9]/*
 usr/lib/ruby/*/cmdtransport[0-9][0-9].rb
 usr/share/*/transport[0-9][0-9].yaml
 usr/share/gz/*-transport*/*-transport[0-9][0-9].tag.xml


### PR DESCRIPTION
I think that we have three kind of things installed in usr/lib/, cmake subdir, pkgconfig subdir and the library itself. These three are listed in the lines above the one I'm removing `*/*/transport[0-9][0-9]/*` which actually includes all them.

Let's try it: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-transport12-debbuilder)](https://build.osrfoundation.org/job/ign-transport12-debbuilder/)